### PR TITLE
fix the Search feature not working for Windows

### DIFF
--- a/scripts/dev/dev.ts
+++ b/scripts/dev/dev.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import cp from "child_process";
 import { findApp, promptForApp } from "../utils";
 import type { App } from "../utils/utils";
@@ -13,7 +14,7 @@ async function go() {
     await saveDb({ lastDevvedApp: app.relativePath });
   } else {
     if (/^\d+$/.test(search)) {
-      search = `exercise/${search.padStart(2, "0")}`;
+      search = path.join('exercise', search.padStart(2, "0"));
     }
 
     app = await findApp(search);

--- a/scripts/diff/diff.ts
+++ b/scripts/diff/diff.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import cp from "child_process";
 import { findApp, promptForApp, guessNextApp, readDb, saveDb } from "../utils";
 import type { App } from "../utils/utils";
@@ -16,11 +17,11 @@ async function go() {
     await saveDb({ lastDiffedApp: secondApp.relativePath });
   } else {
     if (/^\d+$/.test(first)) {
-      first = `./exercise/${first.padStart(2, "0")}`;
+      first = path.join("exercise", first.padStart(2, "0"));
     }
 
     if (/^\d+$/.test(second)) {
-      second = `./final/${second.padStart(2, "0")}`;
+      second = path.join("final", second.padStart(2, "0"));
     }
 
     if (!second) {


### PR DESCRIPTION
Search feature was not working on windows because of usage of forward slashes in the script as oppose to windows backward slash.

Fixed the logic by using `Path.join` to normalize the slashes and allow the search feature to work for `dev` and `diff` script.

Before Fix:

![image](https://user-images.githubusercontent.com/28304828/193850629-3fb38dd5-b952-475f-b222-de05d28aab34.png)


After Fix:

![image](https://user-images.githubusercontent.com/28304828/193850414-ffa677de-3abc-49cf-aefd-8bca2fb1363e.png)
